### PR TITLE
C-linkage

### DIFF
--- a/libudev.h
+++ b/libudev.h
@@ -3,6 +3,10 @@
 
 #include <sys/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct udev;
 struct udev_list_entry;
 struct udev_device;
@@ -102,5 +106,9 @@ struct udev_device *udev_monitor_receive_device(
     struct udev_monitor *udev_monitor);
 const char *udev_device_get_action(struct udev_device *udev_device);
 struct udev *udev_monitor_get_udev(struct udev_monitor *udev_monitor);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* LIBUDEV_H_ */


### PR DESCRIPTION
This fixes an issue with kwin:
    CMakeFiles/kwin.dir/udev.cpp.o: In function `KWin::Udev::Udev()':
        /wrkdirs/usr/ports/x11-wm/plasma5-kwin/work/kwin-5.10.4/udev.cpp:32:
        undefined reference to `udev_new()'
    [...]