### PR TITLE
Fix up udev_enumerate_scan_devices()

### DIFF
--- a/udev-filter.c
+++ b/udev-filter.c
@@ -130,7 +130,8 @@ udev_filter_match(struct udev *udev, struct udev_filter_head *ufh,
 		return (0);
 
 	sysname = get_sysname_by_syspath(syspath);
-	ret = false;
+	/* An empty filter list accepts everything. */
+	ret = STAILQ_EMPTY(ufh);
 
 	STAILQ_FOREACH(ufe, ufh, next) {
 		if (ufe->type == UDEV_FILTER_TYPE_SUBSYSTEM &&


### PR DESCRIPTION
The Linux implementation of scan_devices() returns all devices if you don't have any filters set, while libudev-devd returns none at all; change behavior to match Linux. (All that is needed is that empty filter lists should default return value to true, and then the FOREACH loops will do nothing).