### PR TITLE
Add udev_enumerate_scan_subsystems()

### DIFF
--- a/libudev.h
+++ b/libudev.h
@@ -77,6 +77,7 @@ int udev_enumerate_add_match_tag(struct udev_enumerate *udev_enumerate,
 int udev_enumerate_add_match_is_initialized(
     struct udev_enumerate *udev_enumerate);
 int udev_enumerate_scan_devices(struct udev_enumerate *udev_enumerate);
+int udev_enumerate_scan_subsystems(struct udev_enumerate *udev_enumerate);
 struct udev_list_entry *udev_enumerate_get_list_entry(
     struct udev_enumerate *udev_enumerate);
 int udev_enumerate_add_syspath(struct udev_enumerate *udev_enumerate,

--- a/udev-enumerate.c
+++ b/udev-enumerate.c
@@ -161,7 +161,7 @@ udev_enumerate_add_match_tag(struct udev_enumerate *ue, const char *tag)
 }
 
 
-LIBUDEV_EXPORT int 
+LIBUDEV_EXPORT int
 udev_enumerate_add_match_is_initialized(struct udev_enumerate *ue)
 {
 
@@ -196,6 +196,7 @@ udev_enumerate_scan_devices(struct udev_enumerate *ue)
 
 	udev_list_free(&ue->dev_list);
 	ctx = (struct scan_ctx) {
+		.recursive = true,
 		.cb = enumerate_cb,
 		.args = ue,
 	};
@@ -207,6 +208,54 @@ udev_enumerate_scan_devices(struct udev_enumerate *ue)
 #endif
 	if (ret == -1)
 		udev_list_free(&ue->dev_list);
+	return ret;
+}
+
+/*
+ * Enumerate subsystems -- under /sys/modules, /sys/dev, only
+ * list the directories.
+ */
+static int
+enumerate_ssys_cb(const char *path, int type, void *arg)
+{
+	struct udev_enumerate *ue = arg;
+
+	if (type == DT_DIR) {
+		if (udev_list_insert(&ue->dev_list, path, NULL) == -1)
+			return (-1);
+	}
+	return (0);
+}
+
+LIBUDEV_EXPORT int
+udev_enumerate_scan_subsystems(struct udev_enumerate *ue)
+{
+	int ret = 0;
+
+	TRC("(%p)", ue);
+	udev_list_free(&ue->dev_list);
+
+	struct scan_ctx ctx;
+	char modules_path[DEV_PATH_MAX] = "/sys/modules/";
+	char drivers_path[DEV_PATH_MAX] = "/sys/dev/";
+
+	ctx = (struct scan_ctx) {
+		.recursive = false,
+		.cb = enumerate_ssys_cb,
+		.args = ue,
+	};
+	if (udev_filter_match_subsystem(&(ue->filters), "module"))
+	{
+		ret = scandir_recursive(modules_path, sizeof(modules_path), &ctx);
+	}
+	if (0 && (ret == 0) && (udev_filter_match_subsystem(&(ue->filters), "subsystem")))
+	{
+		/* ret = scandir_recursive(subsystems_path, sizeof(subsystems_path), &ctx); */
+	}
+	if ((ret == 0) && (udev_filter_match_subsystem(&(ue->filters), "driver")))
+	{
+		ret = scandir_recursive(drivers_path, sizeof(drivers_path), &ctx);
+	}
 	return ret;
 }
 

--- a/udev-filter.c
+++ b/udev-filter.c
@@ -205,3 +205,40 @@ out:
 
 	return (ret);
 }
+
+/*
+ * Returns true if the given @p subsystem is accepted by the
+ * filters applied to the enumerator @p ue.
+ */
+bool
+udev_filter_match_subsystem(struct udev_filter_head *ufh, const char *subsystem)
+{
+	if (!subsystem)
+		return false;
+
+	if (STAILQ_EMPTY(ufh))
+		return true;
+
+	struct udev_filter_entry *ufe;
+
+	/* Scan for negative matches */
+	STAILQ_FOREACH(ufe, ufh, next) {
+		if (ufe->type == UDEV_FILTER_TYPE_SUBSYSTEM &&
+			ufe->neg != 0 &&
+			fnmatch(ufe->expr, subsystem, 0) == 0) {
+			return false;
+		}
+	}
+
+	/* Not empty, scan for positive matches */
+	STAILQ_FOREACH(ufe, ufh, next) {
+		if (ufe->type == UDEV_FILTER_TYPE_SUBSYSTEM &&
+			ufe->neg == 0 &&
+			fnmatch(ufe->expr, subsystem, 0) == 0) {
+			return true;
+		}
+	}
+
+	/* Not empty, matched nothing */
+	return false;
+}

--- a/udev-filter.h
+++ b/udev-filter.h
@@ -13,6 +13,8 @@ enum {
 STAILQ_HEAD(udev_filter_head, udev_filter_entry);
 
 void udev_filter_init(struct udev_filter_head *ufh);
+bool udev_filter_match_subsystem(struct udev_filter_head *ufh,
+    const char *subsystem);
 bool udev_filter_match(struct udev *udev, struct udev_filter_head *ufh,
     const char *syspath);
 int udev_filter_add(struct udev_filter_head *ufh, int type, int neg,

--- a/utils.c
+++ b/utils.c
@@ -237,7 +237,7 @@ scandir_sub(char *path, int off, int rem, struct scan_ctx *ctx)
 		off += len;
 		rem -= len;
 
-		if (ent->d_type == DT_DIR) {
+		if ((ctx->recursive) && (ent->d_type == DT_DIR)) {
 			if (rem < 1)
 				break;
 			path[off] = '/';
@@ -264,7 +264,7 @@ scandir_sub(char *path, int off, int rem, struct scan_ctx *ctx)
 int
 scandir_recursive(char *path, size_t len, struct scan_ctx *ctx)
 {
-	size_t root_len = strlen(path);	
+	size_t root_len = strlen(path);
 
 	return (scandir_sub(path, root_len, len - root_len - 1, ctx));
 }

--- a/utils.h
+++ b/utils.h
@@ -1,6 +1,7 @@
 #ifndef UTILS_H_
 #define UTILS_H_
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <unistd.h>
 
@@ -40,7 +41,13 @@ do {									\
 
 typedef int (* scan_cb_t) (const char *path, int type, void *args);
 
+/* If .recursive is true, then .cb gets called for non-dir
+ * paths, an the overall scandir is recursive. If .recursive
+ * is false, then .cb gets called for all paths in the
+ * directory, and scandir is non-recursive.
+ */
 struct scan_ctx {
+	bool recursive;
 	scan_cb_t cb;
 	void *args;
 };


### PR DESCRIPTION
Implement udev_enumerate_scan_subsystems() filtering.

Follow systemd code, explicitly check for driver, modules, but
ignore subsystem because we don't list busses / subsystems.

Adds a udev_filter_match_subsystem() to check if a particular
subsystem is allowed by the filters.

Related changes:
 - allow scandir_recursive to be non-recursive through the context
 - use a different callback to collect subsystems .. only immediate subdirs