### PR TITLE
Add support for DRM hotplug events

### DIFF
--- a/udev-device.h
+++ b/udev-device.h
@@ -9,6 +9,7 @@ enum {
 	UD_ACTION_NONE,
 	UD_ACTION_ADD,
 	UD_ACTION_REMOVE,
+	UD_ACTION_HOTPLUG,
 };
 
 struct udev_device *udev_device_new_common(struct udev *udev,

--- a/udev-monitor.c
+++ b/udev-monitor.c
@@ -152,9 +152,8 @@ parse_devd_message(char *msg, char *syspath, size_t syspathlen)
 		break;
 #endif /* HAVE_DEVINFO_H */
 	case DEVD_EVENT_NOTICE:
-		if (!match_kern_prop_value(msg + 1, "system", "DEVFS"))
-			break;
-		if (!match_kern_prop_value(msg + 1, "subsystem", "CDEV"))
+		if (!(match_kern_prop_value(msg + 1, "system", "DEVFS") && match_kern_prop_value(msg + 1, "subsystem", "CDEV"))
+			&& !match_kern_prop_value(msg + 1, "system", "DRM"))
 			break;
 		type = get_kern_prop_value(msg + 1, "type", &type_len);
 		dev_name = get_kern_prop_value(msg + 1, "cdev", &dev_len);
@@ -168,6 +167,9 @@ parse_devd_message(char *msg, char *syspath, size_t syspathlen)
 		else if (type_len == 7 &&
 		    strncmp(type, "DESTROY", type_len) == 0)
 			action = UD_ACTION_REMOVE;
+		else if (type_len == 7 &&
+		    strncmp(type, "HOTPLUG", type_len) == 0)
+			action = UD_ACTION_HOTPLUG;
 		else
 			break;
 		memcpy(devpath + root_len, dev_name, dev_len);

--- a/udev-utils.c
+++ b/udev-utils.c
@@ -70,6 +70,7 @@ void create_touchpad_handler(struct udev_device *udev_device);
 void create_touchscreen_handler(struct udev_device *udev_device);
 void create_sysmouse_handler(struct udev_device *udev_device);
 void create_kbdmux_handler(struct udev_device *udev_device);
+void create_drm_handler(struct udev_device *udev_device);
 
 struct subsystem_config {
 	char *subsystem;
@@ -131,6 +132,9 @@ struct subsystem_config subsystems[] = {
 	{ "input", DEV_PATH_ROOT "/vboxguest",
 		0,
 		create_mouse_handler },
+	{ "drm", DEV_PATH_ROOT "/dri/card[0-9]*",
+		0,
+		create_drm_handler },
 };
 
 static struct subsystem_config *
@@ -557,5 +561,12 @@ void create_touchscreen_handler(struct udev_device *ud)
 {
 
 	set_input_device_type(ud, IT_TOUCHSCREEN);
+	set_parent(ud);
+}
+
+void
+create_drm_handler(struct udev_device *ud)
+{
+	udev_list_insert(udev_device_get_properties_list(ud), "HOTPLUG", "1");
 	set_parent(ud);
 }


### PR DESCRIPTION
Used by Weston to refresh connectors.

The patch for emitting the event: https://github.com/FreeBSDDesktop/kms-drm/pull/119