### PR TITLE
cirrus-ci: bootstrap pkg

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,8 @@ task:
       image_family: freebsd-12-0
       image: freebsd-11-3-stable-amd64-v20190801
   install_script:
-    - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
+    - sed -i.bak -e 's,quarterly,latest,' /etc/pkg/FreeBSD.conf
+    - env ASSUME_ALWAYS_YES=yes pkg bootstrap -f
     - pkg upgrade -y
     - pkg install -y evdev-proto autoconf automake libtool gmake pkgconf
 


### PR DESCRIPTION
Make sure that we ae running the latest pkg in the newly configured repo.
While hee simplify the sed.

Signed-off-by: Emmanuel Vadot <manu@FreeBSD.Org>