### PR TITLE
Improve procstat check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,12 +35,8 @@ if cc.has_header('devinfo.h')
 	config_h.set('HAVE_DEVINFO_H', '1')
 endif
 
-procstat_inc = '''#include <sys/param.h>
-#include <sys/queue.h>
-#include <sys/socket.h>
-'''
-if cc.has_header_symbol('libprocstat.h', 'procstat_open_sysctl', prefix : procstat_inc)
-	procstat_dep = cc.find_library('procstat')
+procstat_dep = cc.find_library('procstat', required: false)
+if procstat_dep.found()
 	config_h.set('HAVE_LIBPROCSTAT_H', '1')
 endif
 


### PR DESCRIPTION
Use found() method instead of checking for specific headers and symbols.